### PR TITLE
Update get_product_info docstring

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -17,8 +17,12 @@ def read_barcode_from_image(image):
 
 def get_product_info(barcode):
     """
-    Récupère les informations d'un produit via son code-barres en utilisant l'API OpenFoodFacts.
-    Retourne le nom du produit, les ingrédients et le Nutri-Score.
+    Retrieve product information from OpenFoodFacts using the barcode.
+
+    Returns:
+        name (str or None): Product name or None if the barcode is invalid or an API error occurs.
+        ingredients (str or None): Product ingredients or None if the barcode is invalid or an API error occurs.
+        nutriscore (str or None): Nutri-Score grade or None if the barcode is invalid or an API error occurs.
     """
     url = f"https://world.openfoodfacts.org/api/v0/product/{barcode}.json"
     response = requests.get(url)


### PR DESCRIPTION
## Summary
- expand `get_product_info` docstring to clarify that `name`, `ingredients`, and
  `nutriscore` may be `None` when the barcode is invalid or the API request
  fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501e1ce338832d849b146affe6ab1d