### PR TITLE
Improve error handling

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -27,7 +27,7 @@ def get_product_info(barcode):
         data = response.json()
 
         if data['status'] == 0:
-            return "Produit non trouvé.", None, None
+            return None, None, None
 
         product = data['product']
         name = product.get('product_name', 'Nom non disponible')
@@ -36,7 +36,7 @@ def get_product_info(barcode):
 
         return name, ingredients, nutriscore
     else:
-        return "Erreur lors de la récupération des données.", None, None
+        return None, None, None
 
 # Configuration de l'interface Streamlit
 st.title("Scanner de code-barres et récupération d'informations sur le produit")
@@ -54,7 +54,7 @@ if uploaded_file is not None:
             st.success(f"Code-barres détecté: {barcode_data}")
             name, ingredients, nutriscore = get_product_info(barcode_data)
 
-            if name:
+            if name is not None:
                 # Création du tableau
                 product_info = {
                     "Nom du produit": [name],
@@ -63,6 +63,6 @@ if uploaded_file is not None:
                 }
                 st.table(product_info)
             else:
-                st.error("Informations sur le produit non disponibles.")
+                st.error("Produit non trouv\u00e9 ou erreur lors de la r\u00e9cuperation des donn\u00e9es.")
         else:
             st.error("Aucun code-barres trouvé dans l'image.")


### PR DESCRIPTION
## Summary
- return `None` tuple when product API lookup fails
- show error message when lookup is unsuccessful

## Testing
- `python -m py_compile streamlit.py`

------
https://chatgpt.com/codex/tasks/task_e_68501e18fc24832da5c7e1b6382c6494