### PR TITLE
Add Streamlit caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# FoodScan
+
+Cette application Streamlit permet de lire un code-barres depuis une image puis d'afficher les informations du produit depuis OpenFoodFacts.
+
+## Optimisation du cache
+
+La fonction `get_product_info` utilise désormais le décorateur `@st.cache_data` (ou `@st.experimental_memo` selon la version de Streamlit). Cette mise en cache évite d'effectuer plusieurs requêtes réseau pour un même code‑barres : si le même identifiant est scanné à nouveau, les données sont récupérées directement depuis le cache.
+
+Pour exécuter les tests :
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/streamlit.py
+++ b/streamlit.py
@@ -3,6 +3,11 @@ from pyzbar.pyzbar import decode
 from PIL import Image
 import requests
 
+try:
+    cache_decorator = st.cache_data
+except AttributeError:  # pragma: no cover - for older Streamlit versions
+    cache_decorator = st.experimental_memo
+
 def read_barcode_from_image(image):
     """
     Lit le code-barres à partir d'une image PIL et retourne les données décodées.
@@ -15,6 +20,7 @@ def read_barcode_from_image(image):
 
     return None
 
+@cache_decorator
 def get_product_info(barcode):
     """
     Retrieve product information from OpenFoodFacts using the barcode.


### PR DESCRIPTION
## Summary
- use `st.cache_data` or `st.experimental_memo` to cache product info
- implement a simple caching stub for tests and add cache clearing
- verify caching behaviour with a new unit test
- document caching in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850254a5dd0832d83862f7c528c493d