### PR TITLE
Add history tracking and sidebar display

### DIFF
--- a/history.py
+++ b/history.py
@@ -1,0 +1,32 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+HISTORY_FILE = Path("history.json")
+
+
+def load_history(file_path=HISTORY_FILE):
+    """Load history entries from a JSON file."""
+    path = Path(file_path)
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return []
+
+
+def append_history(barcode, name, nutriscore, date=None, file_path=HISTORY_FILE):
+    """Append a new scan entry to the history file."""
+    history = load_history(file_path)
+    entry = {
+        "barcode": barcode,
+        "name": name,
+        "nutriscore": nutriscore,
+        "date": date or datetime.now().isoformat(timespec="seconds"),
+    }
+    history.append(entry)
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(history, f, ensure_ascii=False, indent=2)
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,8 +23,23 @@ sys.modules['PIL'] = pil_stub
 sys.modules['PIL.Image'] = pil_image_stub
 
 st_lib = types.ModuleType('streamlit')
-for attr in ['title', 'file_uploader', 'image', 'button', 'success', 'error', 'table']:
+for attr in ['title', 'file_uploader', 'image', 'button', 'success', 'error', 'table', 'header', 'write']:
     setattr(st_lib, attr, lambda *args, **kwargs: None)
+
+class Sidebar:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def header(self, *a, **k):
+        pass
+
+    def write(self, *a, **k):
+        pass
+
+st_lib.sidebar = Sidebar()
 sys.modules['streamlit'] = st_lib
 
 # Import application module under a different name to avoid conflict with the stubbed library

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,23 @@
+import os
+tempfile = __import__("tempfile")
+
+from history import load_history, append_history
+
+
+def test_load_history_missing():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "history.json")
+        assert load_history(path) == []
+
+
+def test_append_history_adds_entry():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "history.json")
+        append_history("123", "Test", "a", "2024-01-01T00:00:00", path)
+        data = load_history(path)
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["barcode"] == "123"
+        assert entry["name"] == "Test"
+        assert entry["nutriscore"] == "a"
+        assert entry["date"] == "2024-01-01T00:00:00"


### PR DESCRIPTION
## Summary
- add `history.py` for JSON-based storage of scans
- track successful scans in `streamlit.py`
- display history in a sidebar
- patch tests for new sidebar dependency
- test history module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850254e3ce4832d8c6448f4777a0cb7