### PR TITLE
Improve product search using category tags

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -16,13 +16,19 @@ def read_barcode_from_image(image):
     return None
 
 def get_product_info(barcode):
-    """
-    Retrieve product information from OpenFoodFacts using the barcode.
+    """Retrieve product information from OpenFoodFacts using the barcode.
 
     Returns:
-        name (str or None): Product name or None if the barcode is invalid or an API error occurs.
-        ingredients (str or None): Product ingredients or None if the barcode is invalid or an API error occurs.
-        nutriscore (str or None): Nutri-Score grade or None if the barcode is invalid or an API error occurs.
+        name (str or None): Product name or ``None`` if the barcode is invalid
+            or an API error occurs.
+        ingredients (str or None): Product ingredients or ``None`` if the
+            barcode is invalid or an API error occurs.
+        nutriscore (str or None): Nutri-Score grade or ``None`` if the barcode
+            is invalid or an API error occurs.
+        categories (str or None): Comma separated categories or ``None`` if not
+            available.
+        tags (list or None): List of category tags (``categories_tags`` or
+            ``categories_hierarchy``) when present.
     """
     url = f"https://world.openfoodfacts.org/api/v0/product/{barcode}.json"
     response = requests.get(url)
@@ -31,7 +37,7 @@ def get_product_info(barcode):
         data = response.json()
 
         if data.get('status') == 0:
-            return 'Produit non trouvé.', None, None, None
+            return 'Produit non trouvé.', None, None, None, None
 
         product = data.get('product', {})
         name = product.get('product_name', 'Nom non disponible')
@@ -39,22 +45,31 @@ def get_product_info(barcode):
         nutriscore = product.get('nutriscore_grade', 'Nutri-Score non disponible')
 
         categories = product.get('categories', '')
-        return name, ingredients, nutriscore, categories
+        tags = product.get('categories_tags') or product.get('categories_hierarchy')
+        return name, ingredients, nutriscore, categories, tags
     else:
-        return 'Erreur lors de la récupération des données.', None, None, None
+        return 'Erreur lors de la récupération des données.', None, None, None, None
 
 
-def get_better_products(categories, nutriscore):
-    """Return a list of similar products with a better Nutri-Score."""
+def get_better_products(categories, nutriscore, tags=None):
+    """Return a list of similar products with a better Nutri-Score.
+
+    ``tags`` should be the list from ``categories_tags`` or ``categories_hierarchy``
+    if available. The first tag is preferred for the search.
+    """
     nutri_order = ["a", "b", "c", "d", "e"]
 
-    if not categories or nutriscore not in nutri_order:
+    if (not categories and not tags) or nutriscore not in nutri_order:
         return []
 
-    category = categories.split(",")[0].strip()
+    if tags:
+        category = tags[0]
+    else:
+        category = categories.split(",")[0].strip()
     current_index = nutri_order.index(nutriscore)
     better_grades = nutri_order[:current_index]
 
+    results = []
     for grade in better_grades:
         url = (
             "https://world.openfoodfacts.org/cgi/search.pl?"
@@ -65,10 +80,9 @@ def get_better_products(categories, nutriscore):
         if resp.status_code == 200:
             data = resp.json()
             products = [p.get("product_name") for p in data.get("products", []) if p.get("product_name")]
-            if products:
-                return products
+            results.extend(products)
 
-    return []
+    return results
 
 # Configuration de l'interface Streamlit
 st.title("Scanner de code-barres et récupération d'informations sur le produit")
@@ -100,7 +114,7 @@ if image is not None:
 
         if barcode_data:
             st.success(f"Code-barres détecté: {barcode_data}")
-            name, ingredients, nutriscore, categories = get_product_info(barcode_data)
+            name, ingredients, nutriscore, categories, tags = get_product_info(barcode_data)
 
             if ingredients is not None:
                 # Création du tableau
@@ -111,7 +125,7 @@ if image is not None:
                 }
                 st.table(product_info)
 
-                suggestions = get_better_products(categories, nutriscore)
+                suggestions = get_better_products(categories, nutriscore, tags)
                 if suggestions:
                     st.success("Produits similaires de meilleure qualité :")
                     for s in suggestions:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -74,17 +74,19 @@ def test_get_product_info_success(mock_get):
             'product_name': 'Test Product',
             'ingredients_text': 'Water, Sugar',
             'nutriscore_grade': 'a',
-            'categories': 'Snacks, Chips'
+            'categories': 'Snacks, Chips',
+            'categories_tags': ['snacks', 'chips']
         }
     }
     mock_get.return_value = mock_response
 
-    name, ingredients, score, categories = get_product_info('123456')
+    name, ingredients, score, categories, tags = get_product_info('123456')
 
     assert name == 'Test Product'
     assert ingredients == 'Water, Sugar'
     assert score == 'a'
     assert categories == 'Snacks, Chips'
+    assert tags == ['snacks', 'chips']
 
 # Test get_product_info when product not found
 @patch('app_module.requests.get')
@@ -96,28 +98,37 @@ def test_get_product_info_not_found(mock_get):
     }
     mock_get.return_value = mock_response
 
-    name, ingredients, score, categories = get_product_info('0000')
+    name, ingredients, score, categories, tags = get_product_info('0000')
 
     assert name == 'Produit non trouvé.'
     assert ingredients is None
     assert score is None
     assert categories is None
+    assert tags is None
 
 
 # Test get_better_products returns list of product names
 @patch('app_module.requests.get')
 def test_get_better_products(mock_get):
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
+    resp_a = MagicMock()
+    resp_a.status_code = 200
+    resp_a.json.return_value = {
         'products': [
-            {'product_name': 'Better Product'}
+            {'product_name': 'ProdA'}
         ]
     }
-    mock_get.return_value = mock_response
+    resp_b = MagicMock()
+    resp_b.status_code = 200
+    resp_b.json.return_value = {
+        'products': [
+            {'product_name': 'ProdB'}
+        ]
+    }
+    mock_get.side_effect = [resp_a, resp_b]
 
-    result = get_better_products('Snacks', 'c')
-    assert result == ['Better Product']
+    result = get_better_products('Snacks', 'c', ['snacks'])
+    assert result == ['ProdA', 'ProdB']
+    assert 'tag_0=snacks' in mock_get.call_args_list[0][0][0]
 
 # Test get_product_info when API returns error status
 @patch('app_module.requests.get')
@@ -126,9 +137,10 @@ def test_get_product_info_api_error(mock_get):
     mock_response.status_code = 500
     mock_get.return_value = mock_response
 
-    name, ingredients, score, categories = get_product_info('123456')
+    name, ingredients, score, categories, tags = get_product_info('123456')
 
     assert name == 'Erreur lors de la récupération des données.'
     assert ingredients is None
     assert score is None
     assert categories is None
+    assert tags is None


### PR DESCRIPTION
## Summary
- expose category tag data in `get_product_info`
- enhance `get_better_products` to prefer tags and gather all results
- adjust Streamlit app to use new return values
- expand unit tests for tags and multi‑grade search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517153892c832dac612d29c976c0da